### PR TITLE
Include required dependencies in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hca-import-validation
-version = 0.0.1
+version = 0.0.3
 description = HCA Staging Import Validation
 url = https://github.com/dataBiosphere/hca-import-validation
 classifiers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hca-import-validation
-version = 0.0.3
+version = 0.0.4-rc2
 description = HCA Staging Import Validation
 url = https://github.com/dataBiosphere/hca-import-validation
 classifiers =
@@ -11,3 +11,11 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.6
+install_requires =
+    requests
+    google
+    google-cloud-core
+    google-cloud-storage
+    jsonschema
+    more-itertools
+    strict-rfc3339

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hca-import-validation
-version = 0.0.4-rc2
+version = 0.0.4
 description = HCA Staging Import Validation
 url = https://github.com/dataBiosphere/hca-import-validation
 classifiers =


### PR DESCRIPTION
We need to include required dependencies as part of the setup.cfg descriptor using the [install_requires](https://packaging.python.org/guides/distributing-packages-using-setuptools/#install-requires) directive. This is so downstream installers can pull down the correct dependencies when installing.