### PR TITLE
DI-22 debug add retry default to class

### DIFF
--- a/hca/staging_area_validator.py
+++ b/hca/staging_area_validator.py
@@ -47,7 +47,7 @@ class StagingAreaValidator:
         staging_area: str,
         ignore_dangling_inputs: bool,
         validate_json: bool,
-        total_retries,
+        total_retries=10,
     ) -> None:
         super().__init__()
         self.staging_area = staging_area

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hca-import-validation"
-version = "0.0.16"
+version = "0.0.17"
 description = "HCA Staging Import Validation"
 urls = {"Source" = "https://github.com/dataBiosphere/hca-import-validation"}
 classifiers = [

--- a/validate_staging_area.py
+++ b/validate_staging_area.py
@@ -46,10 +46,6 @@ def _parse_args(argv):
 
 if __name__ == "__main__":
     args = _parse_args(sys.argv[1:])
-    adapter = StagingAreaValidator(
-        staging_area=args.staging_area,
-        ignore_dangling_inputs=args.ignore_dangling_inputs,
-        validate_json=args.validate_json,
-        total_retries=args.total_retries,
-    )
+    adapter = StagingAreaValidator(staging_area=args.staging_area, ignore_dangling_inputs=args.ignore_dangling_inputs,
+                                   validate_json=args.validate_json, total_retries=args.total_retries)
     sys.exit(adapter.main())

--- a/validate_staging_area.py
+++ b/validate_staging_area.py
@@ -50,6 +50,6 @@ if __name__ == "__main__":
         staging_area=args.staging_area,
         ignore_dangling_inputs=args.ignore_dangling_inputs,
         validate_json=args.validate_json,
-        total_retries=args.total_retries
+        total_retries=args.total_retries,
     )
     sys.exit(adapter.main())

--- a/validate_staging_area.py
+++ b/validate_staging_area.py
@@ -46,6 +46,10 @@ def _parse_args(argv):
 
 if __name__ == "__main__":
     args = _parse_args(sys.argv[1:])
-    adapter = StagingAreaValidator(staging_area=args.staging_area, ignore_dangling_inputs=args.ignore_dangling_inputs,
-                                   validate_json=args.validate_json, total_retries=args.total_retries)
+    adapter = StagingAreaValidator(
+        staging_area=args.staging_area,
+        ignore_dangling_inputs=args.ignore_dangling_inputs,
+        validate_json=args.validate_json,
+        total_retries=args.total_retries
+    )
     sys.exit(adapter.main())


### PR DESCRIPTION
I had only set retries as a default via cli previously. Fixing that now so that when it is called via the hca-ingest pipelines in Dagster the default is also 10.