### PR TITLE
Lungmap modifications

### DIFF
--- a/hca/staging_area_validator.py
+++ b/hca/staging_area_validator.py
@@ -272,6 +272,14 @@ class StagingAreaValidator:
         if metadata_file := self.metadata_files.get(metadata_id):
             metadata_file["crc32c"] = file_json["crc32c"]
             metadata_versions = metadata_file["metadata_versions"]
+
+            # Sequence file data_files might not be present if they are managed access.
+            # File Descriptor v2.1.0 allows for the drs_uri to be a string or null.
+            # In both of these cases, we set found_data_file to True
+            if metadata_file["entity_type"] == "sequence_file":
+                if "drs_uri" in file_json:
+                    metadata_file["found_data_file"] = True
+
             assert (
                 descriptor_version in metadata_versions
             ), f"Corresponding metadata version for descriptor version {descriptor_version} not found"

--- a/hca/staging_area_validator.py
+++ b/hca/staging_area_validator.py
@@ -258,8 +258,7 @@ class StagingAreaValidator:
 
     def validate_descriptors_file(self, blob: gcs.Blob) -> None:
         # Expected syntax: descriptors/{metadata_type}/{metadata_id}_{version}.json
-        # TODO: remove unused `metadata_type`
-        metadata_type, descriptor_file = blob.name.split("/")[-2:]
+        descriptor_file = blob.name.split("/")[-1]
         assert descriptor_file.count("_") == 1
         assert descriptor_file.endswith(".json")
 


### PR DESCRIPTION
This PR completes two tasks.

**Lookup of DRS_URI in file_descriptors:**
According to [v2.1.0 of the HCA schema file_descriptors](https://schema.humancellatlas.org/system/2.1.0/file_descriptor), a DRS URI can be provided for a file. This means that the actual data file will not be present in the payload, but will be linked externally. As such, we should not flag these data files as being missing in the submission. 

Note, for future, it would be good to check if the there is BOTH a DRS URI and the data_file. If so, you might throw an error.

**Completion of TODO Item:**
There was a note to remove an unused variable. This has been accomplished.